### PR TITLE
Add BlueALSA playback example

### DIFF
--- a/bluealsa_player.py
+++ b/bluealsa_player.py
@@ -1,0 +1,40 @@
+"""BlueALSA 播放工具.
+
+该模块提供通过 BlueALSA 播放 WAV 音频的函数接口, 便于其他脚本调用.
+"""
+
+from __future__ import annotations
+
+import wave
+
+
+import alsaaudio
+
+
+def play_wav_via_bluealsa(wav_file: str, bt_device: str, period_size: int = 1024) -> None:
+    """播放指定的 WAV 文件到蓝牙设备.
+
+    参数:
+        wav_file: WAV 文件路径
+        bt_device: 形如 ``bluealsa:HCI=hci0,DEV=XX:XX:XX:XX:XX:XX,PROFILE=a2dp`` 的设备字符串
+        period_size: ALSA 写入的 period 大小, 默认为 1024
+    """
+    with wave.open(wav_file, "rb") as wf:
+        pcm = alsaaudio.PCM(type=alsaaudio.PCM_PLAYBACK, card=bt_device)
+        try:
+            pcm.setchannels(wf.getnchannels())
+            pcm.setrate(wf.getframerate())
+            fmt = (
+                alsaaudio.PCM_FORMAT_S16_LE
+                if wf.getsampwidth() == 2
+                else alsaaudio.PCM_FORMAT_S8
+            )
+            pcm.setformat(fmt)
+            pcm.setperiodsize(period_size)
+
+            data = wf.readframes(period_size)
+            while data:
+                pcm.write(data)
+                data = wf.readframes(period_size)
+        finally:
+            pcm.close()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,32 @@
+"""BlueALSA 播放示例入口脚本."""
+
+import argparse
+
+from bluealsa_player import play_wav_via_bluealsa
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="通过 BlueALSA 播放 WAV 文件")
+    parser.add_argument("wav_file", help="要播放的 WAV 文件路径")
+    parser.add_argument(
+        "device",
+        help=(
+            "蓝牙设备字符串，如 bluealsa:HCI=hci0,DEV=XX:XX:XX:XX:XX:XX,PROFILE=a2dp"
+        ),
+    )
+    parser.add_argument(
+        "--period",
+        type=int,
+        default=1024,
+        help="ALSA 写入的 period 大小，默认为 1024",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    play_wav_via_bluealsa(args.wav_file, args.device, period_size=args.period)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `bluealsa_player.py` exposing `play_wav_via_bluealsa`
- add `main.py` entry script using this function
- clarify that setting an asoundrc default avoids specifying the MAC address
- remove outdated `dmix` recommendation and move config snippet to the end of README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687862a0c4f08331af42c333ff7ff8b3